### PR TITLE
interfaceAddresses should filter host addresses.

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -102,6 +102,12 @@ export class Connection {
       this.promiseGatherCandidates = new Event();
 
       let address = getHostAddresses(this.useIpv4, this.useIpv6);
+      const { interfaceAddresses } = this.options;
+      if (interfaceAddresses) {
+        address = address.filter((check) =>
+          Object.values(interfaceAddresses).includes(check)
+        );
+      }
       if (this.options.additionalHostAddresses) {
         address = Array.from(
           new Set([...this.options.additionalHostAddresses, ...address])

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -104,9 +104,12 @@ export class Connection {
       let address = getHostAddresses(this.useIpv4, this.useIpv6);
       const { interfaceAddresses } = this.options;
       if (interfaceAddresses) {
-        address = address.filter((check) =>
+        const filteredAddresses = address.filter((check) =>
           Object.values(interfaceAddresses).includes(check)
         );
+        if (filteredAddresses.length) {
+          address = filteredAddresses;
+        }
       }
       if (this.options.additionalHostAddresses) {
         address = Array.from(


### PR DESCRIPTION
I'm unsure if this is the correct way to do this: I need to filter what addresses are used in the ice gathering stage. For example, my server has 192.168.2.124 and 192.168.2.136. I would imagine that setting `interfaceAddresses.udp4` to 191.168.2.124 would prevent anything but that interface address from being used. But it does not, and it sends the 192.168.2.136 candidate anyways.

As far as I can tell that option is used for STUN and TURN but not for local candidates, which seems incorrect. This fixes that issue.