### PR TITLE
Do not regenerate cookie every time flight 2 is sent.

### DIFF
--- a/packages/dtls/src/flight/server/flight2.ts
+++ b/packages/dtls/src/flight/server/flight2.ts
@@ -131,7 +131,7 @@ export const flight2 =
 
     cipher.localKeyPair = generateKeyPair(cipher.namedCurve);
 
-    dtls.cookie = randomBytes(20);
+    dtls.cookie ||= randomBytes(20);
     const helloVerifyReq = new ServerHelloVerifyRequest(
       {
         major: 255 - 1,


### PR DESCRIPTION
Chrome sometimes sends multiple dtls client hello, causing werift to create multiple cookie, overwriting prior. Chrome will use the first cookie, while werift will only have record of the second cookie. This causes DTLS handshake to fail.