### PR TITLE
exclude all inactive descriptions from bundle answer

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -1367,7 +1367,9 @@ export class RTCPeerConnection extends EventTarget {
     if (this.config.bundlePolicy !== "disable") {
       const bundle = new GroupDescription("BUNDLE", []);
       description.media.forEach((media) => {
-        bundle.items.push(media.rtp.muxId!);
+        if (media.direction !== "inactive") {
+          bundle.items.push(media.rtp.muxId!);
+        }
       });
       description.group.push(bundle);
     }


### PR DESCRIPTION
Fix to solve #337.

When building the SDP for a negotiation answer, werift includes all media descriptions, including inactive ones, in the BUNDLE description. This PR would make werift only include non-inactive descriptions, which seems to match the behavior of browser WebRTC implementations and werift's offer construction logic.

This repo can create an example of the specific problem I was running into:

https://github.com/benharp/werift-mvb 