### PR TITLE
move nonstandard into exports

### DIFF
--- a/packages/rtp/src/index.ts
+++ b/packages/rtp/src/index.ts
@@ -1,9 +1,9 @@
 import "buffer";
 export * from "../../common/src";
 export * from "./codec";
-export * from "./container";
+// export * from "./container";
 export * from "./helper";
-export * from "./processor";
+// export * from "./processor";
 export * from "./rtcp/header";
 export * from "./rtcp/psfb";
 export * from "./rtcp/psfb/pictureLossIndication";

--- a/packages/rtp/src/processor/mp4.ts
+++ b/packages/rtp/src/processor/mp4.ts
@@ -1,13 +1,12 @@
 import Event from "rx.mini";
 
+import { buffer2ArrayBuffer, OpusRtpPayload } from "..";
 import {
   annexb2avcc,
-  buffer2ArrayBuffer,
   DataType,
   Mp4Container,
   Mp4SupportedCodec,
-  OpusRtpPayload,
-} from "..";
+} from "../container/mp4";
 import { AVProcessor } from "./interface";
 
 export type Mp4Input = {

--- a/packages/rtp/src/processor/ntpTime.ts
+++ b/packages/rtp/src/processor/ntpTime.ts
@@ -1,13 +1,8 @@
 import { randomUUID } from "crypto";
 
-import {
-  Max32Uint,
-  ntpTime2Sec,
-  Processor,
-  RtcpPacket,
-  RtcpSrPacket,
-  RtpPacket,
-} from "..";
+import { ntpTime2Sec, RtcpPacket, RtcpSrPacket, RtpPacket } from "..";
+import { Processor } from "./interface";
+import { Max32Uint } from "./webm";
 
 export type NtpTimeInput = {
   rtp?: RtpPacket;

--- a/packages/rtp/src/processor/rtpTime.ts
+++ b/packages/rtp/src/processor/rtpTime.ts
@@ -1,5 +1,6 @@
-import { int, Max32Uint, RtpPacket } from "..";
+import { int, RtpPacket } from "..";
 import { Processor } from "./interface";
+import { Max32Uint } from "./webm";
 
 export type RtpTimeInput = {
   rtp?: RtpPacket;

--- a/packages/rtp/src/processor/webm.ts
+++ b/packages/rtp/src/processor/webm.ts
@@ -5,7 +5,7 @@ import {
   numberToByteArray,
   vintEncode,
   WEBMContainer,
-} from "..";
+} from "../container";
 import { SupportedCodec } from "../container/webm";
 import { AVProcessor } from "./interface";
 

--- a/packages/rtp/tests/processor/ntpTime.test.ts
+++ b/packages/rtp/tests/processor/ntpTime.test.ts
@@ -1,12 +1,5 @@
-import {
-  int,
-  Max32Uint,
-  NtpTimeBase,
-  RtcpSenderInfo,
-  RtcpSrPacket,
-  RtpHeader,
-  RtpPacket,
-} from "../../src";
+import { RtcpSenderInfo, RtcpSrPacket, RtpHeader, RtpPacket } from "../../src";
+import { Max32Uint, NtpTimeBase } from "../../src/processor";
 
 describe("ntpTime", () => {
   it("rollover", () => {

--- a/packages/rtp/tests/processor/rtpTime.test.ts
+++ b/packages/rtp/tests/processor/rtpTime.test.ts
@@ -1,4 +1,5 @@
-import { int, Max32Uint, RtpHeader, RtpPacket, RtpTimeBase } from "../../src";
+import { int, RtpHeader, RtpPacket } from "../../src";
+import { Max32Uint, RtpTimeBase } from "../../src/processor";
 
 describe("rtpTime", () => {
   it("rollover", () => {

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -16,6 +16,10 @@
     "name": "shinyoshiaki"
   },
   "main": "lib/webrtc/src/index.js",
+  "exports": {
+    ".": "./lib/webrtc/src/index.js",
+    "./nonstandard": "./lib/webrtc/src/nonstandard/index.js"
+  },
   "types": "lib/webrtc/src/index.d.ts",
   "files": [
     "lib",

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -10,8 +10,6 @@ export * from "./media/rtpReceiver";
 export * from "./media/rtpSender";
 export * from "./media/rtpTransceiver";
 export * from "./media/track";
-export * from "./nonstandard/recorder";
-export * from "./nonstandard/userMedia";
 export * from "./peerConnection";
 export * from "./sdp";
 export * from "./transport/dtls";

--- a/packages/webrtc/src/nonstandard/index.ts
+++ b/packages/webrtc/src/nonstandard/index.ts
@@ -1,0 +1,2 @@
+export * from "./recorder";
+export * from "./userMedia";

--- a/packages/webrtc/src/nonstandard/recorder/writer/webm.ts
+++ b/packages/webrtc/src/nonstandard/recorder/writer/webm.ts
@@ -6,14 +6,13 @@ import {
   DepacketizeCallback,
   JitterBufferCallback,
   LipsyncCallback,
-  MediaStreamTrack,
   NtpTimeCallback,
   RtcpSourceCallback,
   RtpSourceCallback,
   saveToFileSystem,
   WebmCallback,
-  WeriftError,
-} from "../../..";
+} from "../../../../../rtp/src/processor";
+import { MediaStreamTrack, WeriftError } from "../../..";
 import { MediaWriter } from ".";
 
 const sourcePath = "packages/webrtc/src/nonstandard/recorder/writer/webm.ts";


### PR DESCRIPTION
Building on previous change. https://github.com/shinyoshiaki/werift-webrtc/pull/359

The primary goal is to remove mp4box as an automatically included dependency, which is large, and also pulls in a significant portion of lodash.

```ts
import nonstandard from "werift/nonstandard";
```

This requires module resolution node 16 set in tsconfig when used by typescript. which shouldn't be a problem since this library requires node 16 anyways.

https://stackoverflow.com/a/72275458