### PR TITLE
Fix reconfig timeout leak

### DIFF
--- a/packages/sctp/src/sctp.ts
+++ b/packages/sctp/src/sctp.ts
@@ -1187,6 +1187,7 @@ export class SCTP {
       this.timer1Cancel();
       this.timer2Cancel();
       this.timer3Cancel();
+      this.timerReconfigCancel();
       this.setConnectionState("closed");
       this.removeAllListeners();
     }
@@ -1206,6 +1207,7 @@ export class SCTP {
     clearTimeout(this.timer1Handle);
     clearTimeout(this.timer2Handle);
     clearTimeout(this.timer3Handle);
+    clearTimeout(this.timerReconfigHandle);
   }
 
   async abort() {


### PR DESCRIPTION
Only the change in `stop` method is needed to avoid the leak. Just in case, I also made a change to `setState` method as it looks like it could also cancel it there but no idea

I almost didn't find this awesome library, thanks! Hidden gem