### PR TITLE
Update buffer-crc32 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2927,11 +2927,11 @@
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -7292,7 +7292,7 @@
       "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "^0.2.13",
+        "buffer-crc32": "^1.0.0",
         "debug": "^4.3.4",
         "int64-buffer": "^1.0.1",
         "ip": "^1.1.8",
@@ -7448,7 +7448,7 @@
         "@shinyoshiaki/ebml-builder": "^0.0.1",
         "aes-js": "^3.1.2",
         "binary-data": "^0.6.0",
-        "buffer-crc32": "^0.2.13",
+        "buffer-crc32": "^1.0.0",
         "date-fns": "^2.29.3",
         "debug": "^4.3.4",
         "int64-buffer": "^1.0.1",
@@ -9741,9 +9741,9 @@
       }
     },
     "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -12793,7 +12793,7 @@
         "@types/uuid": "^9.0.0",
         "aes-js": "^3.1.2",
         "binary-data": "^0.6.0",
-        "buffer-crc32": "^0.2.13",
+        "buffer-crc32": "^1.0.0",
         "date-fns": "^2.29.3",
         "debug": "^4.3.4",
         "int64-buffer": "^1.0.1",
@@ -12858,7 +12858,7 @@
         "@types/lodash": "^4.14.191",
         "@types/utf8": "^3.0.1",
         "@types/ws": "^8.5.3",
-        "buffer-crc32": "^0.2.13",
+        "buffer-crc32": "^1.0.0",
         "debug": "^4.3.4",
         "int64-buffer": "^1.0.1",
         "ip": "^1.1.8",

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -26,7 +26,7 @@
     "upgrade-interactive": "npx npm-check-updates -i"
   },
   "dependencies": {
-    "buffer-crc32": "^0.2.13",
+    "buffer-crc32": "^1.0.0",
     "debug": "^4.3.4",
     "int64-buffer": "^1.0.1",
     "ip": "^1.1.8",

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -36,7 +36,6 @@
     "rx.mini": "^1.2.2"
   },
   "devDependencies": {
-    "@types/buffer-crc32": "^0.2.2",
     "@types/debug": "^4.1.7",
     "@types/ip": "^1.1.0",
     "@types/lodash": "^4.14.191",

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@types/aes-js": "^3.1.1",
-    "@types/buffer-crc32": "^0.2.2",
     "@types/debug": "^4.1.7",
     "@types/ip": "^1.1.0",
     "@types/jest": "^29.2.4",

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -47,7 +47,7 @@
     "@shinyoshiaki/ebml-builder": "^0.0.1",
     "aes-js": "^3.1.2",
     "binary-data": "^0.6.0",
-    "buffer-crc32": "^0.2.13",
+    "buffer-crc32": "^1.0.0",
     "date-fns": "^2.29.3",
     "debug": "^4.3.4",
     "int64-buffer": "^1.0.1",


### PR DESCRIPTION
Hey! We've spent some effort lately to clean up the buffer-crc32 library and push the 1.0.0 release forward. Thought you may want to upgrade! Should be a drop-in replacement, as you don't support very old Node.js versions already.