### PR TITLE
use multicast-dns to resolve local addresses

### DIFF
--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -13,7 +13,10 @@
   "license": "MIT",
   "author": "shinyoshiaki <shinyoshiaki2012@gmail.com>",
   "main": "lib/ice/src/index.js",
-  "files": ["src", "lib"],
+  "files": [
+    "src",
+    "lib"
+  ],
   "scripts": {
     "build": "npm run format && tsc -p ./tsconfig.production.json",
     "deploy": "npm run build && npm publish",
@@ -32,6 +35,7 @@
     "ip": "^1.1.8",
     "jspack": "^0.0.4",
     "lodash": "^4.17.21",
+    "multicast-dns": "^7.2.5",
     "p-cancelable": "^2.1.1",
     "rx.mini": "^1.2.2"
   },
@@ -39,6 +43,7 @@
     "@types/debug": "^4.1.7",
     "@types/ip": "^1.1.0",
     "@types/lodash": "^4.14.191",
+    "@types/multicast-dns": "^7.2.4",
     "@types/utf8": "^3.0.1",
     "@types/ws": "^8.5.3",
     "ws": "^8.11.0"

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -11,7 +11,7 @@ import timers from "timers/promises";
 
 import { InterfaceAddresses } from "../../common/src/network";
 import { Candidate, candidateFoundation, candidatePriority } from "./candidate";
-import { DnsLookup } from "./dns/lookup";
+import { DnsLookup, MdnsLookup } from "./dns/lookup";
 import { TransactionError } from "./exceptions";
 import { Future, PQueue, difference, future, randomString } from "./helper";
 import { classes, methods } from "./stun/const";
@@ -40,7 +40,7 @@ export class Connection {
   _localCandidatesEnd = false;
   _tieBreaker: bigint = BigInt(new Uint64BE(randomBytes(64)).toString());
   state: IceState = "new";
-  dnsLookup?: DnsLookup;
+  lookup?: DnsLookup | MdnsLookup;
   restarted = false;
 
   readonly onData = new Event<[Buffer, number]>();
@@ -462,7 +462,7 @@ export class Connection {
     this.protocols = [];
     this.localCandidates = [];
 
-    await this.dnsLookup?.close();
+    await this.lookup?.close();
   }
 
   private setState(state: IceState) {
@@ -487,10 +487,10 @@ export class Connection {
     if (remoteCandidate.host.includes(".local")) {
       try {
         if (this.state === "closed") return;
-        if (!this.dnsLookup) {
-          this.dnsLookup = new DnsLookup();
+        if (!this.lookup) {
+          this.lookup = process.platform === 'darwin' ? new DnsLookup() : new MdnsLookup();
         }
-        const host = await this.dnsLookup.lookup(remoteCandidate.host);
+        const host = await this.lookup.lookup(remoteCandidate.host);
         remoteCandidate.host = host;
       } catch (error) {
         return;

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -11,9 +11,9 @@ import timers from "timers/promises";
 
 import { InterfaceAddresses } from "../../common/src/network";
 import { Candidate, candidateFoundation, candidatePriority } from "./candidate";
-import { DnsLookup, MdnsLookup } from "./dns/lookup";
+import { MdnsLookup } from "./dns/lookup";
 import { TransactionError } from "./exceptions";
-import { Future, PQueue, difference, future, randomString } from "./helper";
+import { Future, PQueue, future, randomString } from "./helper";
 import { classes, methods } from "./stun/const";
 import { Message, parseMessage } from "./stun/message";
 import { StunProtocol } from "./stun/protocol";
@@ -40,7 +40,7 @@ export class Connection {
   _localCandidatesEnd = false;
   _tieBreaker: bigint = BigInt(new Uint64BE(randomBytes(64)).toString());
   state: IceState = "new";
-  lookup?: DnsLookup | MdnsLookup;
+  lookup?: MdnsLookup;
   restarted = false;
 
   readonly onData = new Event<[Buffer, number]>();
@@ -488,7 +488,7 @@ export class Connection {
       try {
         if (this.state === "closed") return;
         if (!this.lookup) {
-          this.lookup = process.platform === 'darwin' ? new DnsLookup() : new MdnsLookup();
+          this.lookup = new MdnsLookup();
         }
         const host = await this.lookup.lookup(remoteCandidate.host);
         remoteCandidate.host = host;


### PR DESCRIPTION
safari and now chrome will exchange ice candidates with mdns local addresses, ie:

```
83c0adfa-97f2-49c0-af07-deb9340ee710.local
```

This is done to prevent privacy leaks. 
https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-mdns-ice-candidates-04

My previous change was using dns.lookup to resolve these local addresses. However, that method only works on Mac, which provides transparent mdns lookup via dns-sd. Linux and Windows need to resolve this via a third party library. I'm using multicast-dns in this case.
