### PR TITLE
Add getConfiguration() to RTCPeerConnection

### DIFF
--- a/doc/classes/RTCPeerConnection.md
+++ b/doc/classes/RTCPeerConnection.md
@@ -72,6 +72,7 @@
 - [createOffer](RTCPeerConnection.md#createoffer)
 - [emit](RTCPeerConnection.md#emit)
 - [eventNames](RTCPeerConnection.md#eventnames)
+- [getConfiguration](RTCPeerConnection.md#getconfiguration)
 - [getMaxListeners](RTCPeerConnection.md#getmaxlisteners)
 - [getReceivers](RTCPeerConnection.md#getreceivers)
 - [getSenders](RTCPeerConnection.md#getsenders)
@@ -664,6 +665,16 @@ v6.0.0
 #### Inherited from
 
 EventTarget.eventNames
+
+___
+
+### getConfiguration
+
+▸ **getConfiguration**(): [`PeerConfig`](../interfaces/PeerConfig.md)
+
+#### Returns
+
+[`PeerConfig`](../interfaces/PeerConfig.md)
 
 ___
 

--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -243,6 +243,10 @@ export class RTCPeerConnection extends EventTarget {
     );
   }
 
+  getConfiguration() {
+    return this.config;
+  }
+
   async createOffer() {
     await this.ensureCerts();
     const description = this.buildOfferSdp();


### PR DESCRIPTION
This PR adds the missing `getConfiguration()` method (https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-getconfiguration) to the `RTCPeerConnection`.

Related issue: #375