### PR TITLE
add local packages as dependencies for werift-webrtc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8836,7 +8836,10 @@
         "rx.mini": "^1.2.2",
         "turbo-crc32": "^1.0.1",
         "tweetnacl": "^1.0.3",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "werift-common": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*"
       },
       "devDependencies": {
         "@types/aes-js": "^3.1.1",
@@ -14978,7 +14981,10 @@
         "rx.mini": "^1.2.2",
         "turbo-crc32": "^1.0.1",
         "tweetnacl": "^1.0.3",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "werift-common": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*"
       },
       "dependencies": {
         "@types/node": {

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -60,7 +60,12 @@
     "rx.mini": "^1.2.2",
     "turbo-crc32": "^1.0.1",
     "tweetnacl": "^1.0.3",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "werift-common": "*",
+    "werift-dtls": "*",
+    "werift-rtp": "*",
+    "werift-sctp": "*",
+    "werift-ice": "*"
   },
   "devDependencies": {
     "@types/aes-js": "^3.1.1",


### PR DESCRIPTION
This PR adds local packages (werift-ice, werift-rtp, werift-common, etc) as dependencies of werift-webrtc.

Related issue: https://github.com/shinyoshiaki/werift-webrtc/issues/386

The `multicast-dns` package was added to werift-ice and was subsequently not being installed with werift-webrtc. This is because we import the werift-ice code with relative imports, i.e.
```typescript
import { Connection } from "../../../ice/src";
```

This was making it impossible to use werift-webrtc without manually adding `multicast-dns` as a dependency of whatever project is using werift-webrtc, otherwise it would throw:
```
node:internal/modules/cjs/loader:1147
  throw err;
  ^

Error: Cannot find module 'multicast-dns'
```

Adding local packages as dependencies of werift-webrtc fixes this issue and any future new dependencies added won't cause problems