### PR TITLE
Fix bug in RTCDtlsTransport class

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Pull requests are always welcome.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
 the promise in the start() method now includes a rejection function to handle errors during the connection process.