### PR TITLE
make remoteIsBundled public

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -874,7 +874,7 @@ export class RTCPeerConnection extends EventTarget {
     return receiveParameters;
   }
 
-  private get remoteIsBundled() {
+  get remoteIsBundled() {
     const remoteSdp = this._remoteDescription;
     if (!remoteSdp) {
       return undefined;


### PR DESCRIPTION
I'm using this, but noticed that it was made private in recent month.