### PR TITLE
fix bufferedAmound inaccuracy, reset queues when empty

### DIFF
--- a/packages/sctp/src/sctp.ts
+++ b/packages/sctp/src/sctp.ts
@@ -568,6 +568,7 @@ export class SCTP {
         this.updateRto(receivedTime - sChunk.sentTime!);
       }
     }
+    // Furthermore, this exposed an issue I've seen in v8 in other projects: using an array as a queue seems to result in long calls to shift (it does an array copy under the hood?). The problem seems to get worse the more times it shifts. Resetting the queue to empty array mitigates this.
     if (!this.sentQueue.length) {
       this.sentQueue = [];
     }
@@ -879,6 +880,7 @@ export class SCTP {
         this.timer3Start();
       }
     }
+    // Resetting the queue to empty array mitigates this.
     this.outboundQueue = [];
     this.flush.execute();
   }
@@ -1097,6 +1099,7 @@ export class SCTP {
         streams[chunk.streamId] = chunk.streamSeqNum;
       }
     }
+    // Resetting the queue to empty array mitigates this.
     if (!this.sentQueue.length) {
       this.sentQueue = [];
     }

--- a/packages/sctp/src/sctp.ts
+++ b/packages/sctp/src/sctp.ts
@@ -84,6 +84,7 @@ const SCTPConnectionStates = [
 type SCTPConnectionState = Unpacked<typeof SCTPConnectionStates>;
 
 export class SCTP {
+  flush = new Event<[void]>();
   readonly stateChanged: {
     [key in SCTPConnectionState]: Event<[]>;
   } = createEventsFromList(SCTPConnectionStates);
@@ -567,6 +568,9 @@ export class SCTP {
         this.updateRto(receivedTime - sChunk.sentTime!);
       }
     }
+    if (!this.sentQueue.length) {
+      this.sentQueue = [];
+    }
 
     // # handle gap blocks
     let loss = false;
@@ -799,7 +803,12 @@ export class SCTP {
     if (!this.timer3Handle) {
       await this.transmit();
     } else {
-      await new Promise((r) => setImmediate(r));
+      if (this.outboundQueue.length) {
+        await this.flush.asPromise();
+      } else {
+        // unreachable?
+        await new Promise((r) => setImmediate(r));
+      }
     }
   };
 
@@ -870,6 +879,8 @@ export class SCTP {
         this.timer3Start();
       }
     }
+    this.outboundQueue = [];
+    this.flush.execute();
   }
 
   async transmitReconfigRequest() {
@@ -1085,6 +1096,9 @@ export class SCTP {
       if (!(chunk.flags & SCTP_DATA_UNORDERED)) {
         streams[chunk.streamId] = chunk.streamSeqNum;
       }
+    }
+    if (!this.sentQueue.length) {
+      this.sentQueue = [];
     }
 
     if (done) {

--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -310,6 +310,7 @@ export class RTCSctpTransport {
         channel.addBufferedAmount(-userData.length);
       }
     }
+    this.dataChannelQueue = [];
   }
 
   datachannelSend = (channel: RTCDataChannel, data: Buffer | string) => {

--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -310,6 +310,7 @@ export class RTCSctpTransport {
         channel.addBufferedAmount(-userData.length);
       }
     }
+    // Resetting the queue to empty array mitigates this.
     this.dataChannelQueue = [];
   }
 


### PR DESCRIPTION
bufferedAmoutn is currently bugged if timer3Handle is accurate, making backpressure based sending impossible.

Furthermore, this exposed an issue I've seen in v8 in other projects: using an array as a queue seems to result in long calls to shift (it does an array copy under the hood?). The problem seems to get worse the more times it shifts. Resetting the queue to empty array mitigates this. 