### PR TITLE
Remove usage of binary-data in hot paths

### DIFF
--- a/packages/dtls/src/cipher/suites/aead.ts
+++ b/packages/dtls/src/cipher/suites/aead.ts
@@ -118,8 +118,6 @@ export default class AEADCipher extends Cipher {
     );
     explicitNonce.copy(iv, this.nonceImplicitLength);
 
-    const encryptedEnd =
-      this.nonceExplicitLength + data.length - this.authTagLength;
     const encrypted = data.subarray(
       this.nonceExplicitLength,
       data.length - this.authTagLength,

--- a/packages/dtls/src/cipher/suites/aead.ts
+++ b/packages/dtls/src/cipher/suites/aead.ts
@@ -95,10 +95,8 @@ export default class AEADCipher extends Cipher {
   encodeAdditionalBuffer(header: CipherHeader, dataLength: number) {
     const additionalBuffer = Buffer.alloc(13);
 
-    // Sequence is an 6-byte unsigned integer, so write that first,
-    // then write the epoch with the correct first two bytes.
-    additionalBuffer.writeBigUInt64BE(BigInt(header.sequenceNumber), 0);
     additionalBuffer.writeUInt16BE(header.epoch, 0);
+    additionalBuffer.writeUintBE(header.sequenceNumber, 2, 6);
     additionalBuffer.writeUInt8(header.type, 8);
     additionalBuffer.writeUInt16BE(header.version, 9);
     additionalBuffer.writeUInt16BE(dataLength, 11);

--- a/packages/dtls/src/cipher/suites/aead.ts
+++ b/packages/dtls/src/cipher/suites/aead.ts
@@ -1,6 +1,5 @@
 import * as crypto from "crypto";
 
-import { createDecode, encode, types } from "@shinyoshiaki/binary-data";
 import { dumpBuffer, getObjectSummary } from "../../helper";
 import { debug } from "../../imports/common";
 import { prfEncryptionKeys } from "../prf";
@@ -9,19 +8,6 @@ import Cipher, {
   SessionType,
   type SessionTypes,
 } from "./abstract";
-
-const { uint8, uint16be, uint48be } = types;
-
-const ContentType = uint8;
-const ProtocolVersion = uint16be;
-
-const AEADAdditionalData = {
-  epoch: uint16be,
-  sequence: uint48be,
-  type: ContentType,
-  version: ProtocolVersion,
-  length: uint16be,
-};
 
 const err = debug(
   "werift-dtls : packages/dtls/src/cipher/suites/aead.ts : err",
@@ -84,15 +70,7 @@ export default class AEADCipher extends Cipher {
 
     const explicitNonce = iv.slice(this.nonceImplicitLength);
 
-    const additionalData = {
-      epoch: header.epoch,
-      sequence: header.sequenceNumber,
-      type: header.type,
-      version: header.version,
-      length: data.length,
-    };
-
-    const additionalBuffer = encode(additionalData, AEADAdditionalData).slice();
+    const additionalBuffer = this.encodeAdditionalBuffer(header, data.length);
 
     const cipher = crypto.createCipheriv(
       this.blockAlgorithm as crypto.CipherCCMTypes,
@@ -114,6 +92,20 @@ export default class AEADCipher extends Cipher {
     return Buffer.concat([explicitNonce, headPart, finalPart, authTag]);
   }
 
+  encodeAdditionalBuffer(header: CipherHeader, dataLength: number) {
+    const additionalBuffer = Buffer.alloc(13);
+
+    // Sequence is an 6-byte unsigned integer, so write that first,
+    // then write the epoch with the correct first two bytes.
+    additionalBuffer.writeBigUInt64BE(BigInt(header.sequenceNumber), 0);
+    additionalBuffer.writeUInt16BE(header.epoch, 0);
+    additionalBuffer.writeUInt8(header.type, 8);
+    additionalBuffer.writeUInt16BE(header.version, 9);
+    additionalBuffer.writeUInt16BE(dataLength, 11);
+
+    return additionalBuffer;
+  }
+
   /**
    * Decrypt message.
    */
@@ -123,23 +115,23 @@ export default class AEADCipher extends Cipher {
     const writeKey = isClient ? this.serverWriteKey : this.clientWriteKey;
     if (!iv || !writeKey) throw new Error();
 
-    const final = createDecode(data);
-
-    const explicitNonce = final.readBuffer(this.nonceExplicitLength);
+    const explicitNonce = Buffer.from(
+      data.subarray(0, this.nonceExplicitLength),
+    );
     explicitNonce.copy(iv, this.nonceImplicitLength);
 
-    const encrypted = final.readBuffer(final.length - this.authTagLength);
-    const authTag = final.readBuffer(this.authTagLength);
+    const encryptedEnd =
+      this.nonceExplicitLength + data.length - this.authTagLength;
+    const encrypted = data.subarray(
+      this.nonceExplicitLength,
+      data.length - this.authTagLength,
+    );
+    const authTag = data.subarray(data.length - this.authTagLength);
 
-    const additionalData = {
-      epoch: header.epoch,
-      sequence: header.sequenceNumber,
-      type: header.type,
-      version: header.version,
-      length: encrypted.length,
-    };
-
-    const additionalBuffer = encode(additionalData, AEADAdditionalData).slice();
+    const additionalBuffer = this.encodeAdditionalBuffer(
+      header,
+      encrypted.length,
+    );
 
     const decipher = crypto.createDecipheriv(
       this.blockAlgorithm as crypto.CipherCCMTypes,

--- a/packages/dtls/src/context/cipher.ts
+++ b/packages/dtls/src/context/cipher.ts
@@ -1,7 +1,7 @@
 import nodeCrypto, { createSign } from "crypto";
 import { Certificate, PrivateKey } from "@fidm/x509";
 import * as x509 from "@peculiar/x509";
-import { decode, encode, types } from "@shinyoshiaki/binary-data";
+import { encode, types } from "@shinyoshiaki/binary-data";
 import { addYears } from "date-fns";
 
 import {
@@ -127,12 +127,11 @@ export class CipherContext {
 
   encryptPacket(pkt: DtlsPlaintext) {
     const header = pkt.recordLayerHeader;
+    const version =
+      (header.protocolVersion.major << 8) | header.protocolVersion.minor;
     const enc = this.cipher.encrypt(this.sessionType, pkt.fragment, {
       type: header.contentType,
-      version: decode(
-        Buffer.from(encode(header.protocolVersion, ProtocolVersion).slice()),
-        { version: types.uint16be },
-      ).version,
+      version,
       epoch: header.epoch,
       sequenceNumber: header.sequenceNumber,
     });
@@ -143,12 +142,11 @@ export class CipherContext {
 
   decryptPacket(pkt: DtlsPlaintext) {
     const header = pkt.recordLayerHeader;
+    const version =
+      (header.protocolVersion.major << 8) | header.protocolVersion.minor;
     const dec = this.cipher.decrypt(this.sessionType, pkt.fragment, {
       type: header.contentType,
-      version: decode(
-        Buffer.from(encode(header.protocolVersion, ProtocolVersion).slice()),
-        { version: types.uint16be },
-      ).version,
+      version,
       epoch: header.epoch,
       sequenceNumber: header.sequenceNumber,
     });

--- a/packages/dtls/src/record/message/plaintext.ts
+++ b/packages/dtls/src/record/message/plaintext.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { decode, encode, types } from "@shinyoshiaki/binary-data";
+import { types } from "@shinyoshiaki/binary-data";
 
 import { dumpBuffer } from "../../helper";
 import { DtlsPlaintextHeader, MACHeader } from "./header";
@@ -29,16 +29,56 @@ export class DtlsPlaintext {
   }
 
   static deSerialize(buf: Buffer) {
+    if (buf.length < 13) {
+      throw new Error("Invalid DTLS record: buffer is too short");
+    }
+
+    const contentType = buf.readUInt8(0);
+    const majorVersion = buf.readUInt8(1);
+    const minorVersion = buf.readUInt8(2);
+    const epoch = buf.readUInt16BE(3);
+
+    // Read the 6-byte sequence number as a 48-bit integer
+    const sequenceNumber = buf.slice(5, 11).readUIntBE(0, 6);
+
+    const contentLen = buf.readUInt16BE(11);
+
+    // Ensure the buffer has enough data for the fragment
+    if (buf.length < 13 + contentLen) {
+      throw new Error("Invalid DTLS record: fragment length exceeds buffer");
+    }
+
+    const fragment = buf.slice(13, 13 + contentLen);
+
     const r = new DtlsPlaintext(
-      //@ts-ignore
-      ...Object.values(decode(buf, DtlsPlaintext.spec)),
+      {
+        contentType,
+        protocolVersion: { major: majorVersion, minor: minorVersion },
+        epoch,
+        sequenceNumber,
+        contentLen,
+      },
+      fragment,
     );
     return r;
   }
 
   serialize() {
-    const res = encode(this, DtlsPlaintext.spec).slice();
-    return Buffer.from(res);
+    const fragmentLength = this.fragment.length;
+    // 13 bytes for headers + fragment length
+    const totalLength = 13 + fragmentLength;
+
+    const buffer = Buffer.alloc(totalLength);
+
+    buffer.writeUInt8(this.recordLayerHeader.contentType, 0);
+    buffer.writeUInt8(this.recordLayerHeader.protocolVersion.major, 1);
+    buffer.writeUInt8(this.recordLayerHeader.protocolVersion.minor, 2);
+    buffer.writeUInt16BE(this.recordLayerHeader.epoch, 3);
+    buffer.writeUIntBE(this.recordLayerHeader.sequenceNumber, 5, 6);
+    buffer.writeUInt16BE(fragmentLength, 11);
+    this.fragment.copy(buffer, 13);
+
+    return buffer;
   }
 
   computeMACHeader() {


### PR DESCRIPTION
binary-data is creating a stream object per packet for both send and receive. Simplify this to use node's native Buffer objects to parse the payloads.

This builds on my two prior changes.