### PR TITLE
Simplify nonce creation and refactor DtlsPlaintextHeader

### DIFF
--- a/packages/dtls/src/cipher/suites/aead.ts
+++ b/packages/dtls/src/cipher/suites/aead.ts
@@ -113,9 +113,8 @@ export default class AEADCipher extends Cipher {
     const writeKey = isClient ? this.serverWriteKey : this.clientWriteKey;
     if (!iv || !writeKey) throw new Error();
 
-    const explicitNonce = Buffer.from(
-      data.subarray(0, this.nonceExplicitLength),
-    );
+    const explicitNonce = data.subarray(0, this.nonceExplicitLength);
+
     explicitNonce.copy(iv, this.nonceImplicitLength);
 
     const encrypted = data.subarray(

--- a/packages/dtls/src/record/message/header.ts
+++ b/packages/dtls/src/record/message/header.ts
@@ -1,45 +1,15 @@
 import { decode, encode, types } from "@shinyoshiaki/binary-data";
-
 import { ProtocolVersion } from "../../handshake/binary";
 
-export class DtlsPlaintextHeader {
-  static readonly spec = {
-    contentType: types.uint8,
-    protocolVersion: ProtocolVersion,
-    epoch: types.uint16be,
-    sequenceNumber: types.uint48be,
-    contentLen: types.uint16be,
+export interface DtlsPlaintextHeader {
+  contentType: number;
+  protocolVersion: {
+    major: number;
+    minor: number;
   };
-
-  constructor(
-    public contentType: number,
-    public protocolVersion: { major: number; minor: number },
-    public epoch: number,
-    public sequenceNumber: number,
-    public contentLen: number,
-  ) {}
-
-  static createEmpty() {
-    return new DtlsPlaintextHeader(
-      undefined as any,
-      undefined as any,
-      undefined as any,
-      undefined as any,
-      undefined as any,
-    );
-  }
-
-  static deSerialize(buf: Buffer) {
-    return new DtlsPlaintextHeader(
-      //@ts-ignore
-      ...Object.values(decode(buf, DtlsPlaintextHeader.spec)),
-    );
-  }
-
-  serialize() {
-    const res = encode(this, DtlsPlaintextHeader.spec).slice();
-    return Buffer.from(res);
-  }
+  epoch: number;
+  sequenceNumber: number;
+  contentLen: number;
 }
 
 export class MACHeader {

--- a/packages/dtls/src/record/message/plaintext.ts
+++ b/packages/dtls/src/record/message/plaintext.ts
@@ -1,19 +1,9 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import { types } from "@shinyoshiaki/binary-data";
-
 import { dumpBuffer } from "../../helper";
-import { DtlsPlaintextHeader, MACHeader } from "./header";
+import { type DtlsPlaintextHeader, MACHeader } from "./header";
 
 export class DtlsPlaintext {
-  static readonly spec = {
-    recordLayerHeader: DtlsPlaintextHeader.spec,
-    fragment: types.buffer(
-      (context: any) => context.current.recordLayerHeader.contentLen,
-    ),
-  };
-
   constructor(
-    public recordLayerHeader: typeof DtlsPlaintext.spec.recordLayerHeader,
+    public recordLayerHeader: DtlsPlaintextHeader,
     public fragment: Buffer,
   ) {}
 


### PR DESCRIPTION
Streamline the nonce creation process in AEADCipher and convert DtlsPlaintextHeader to an interface, enhancing code clarity and maintainability.