### PR TITLE
Make the sessionDescription argument of setLocalDescription optional

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -613,10 +613,19 @@ export class RTCPeerConnection extends EventTarget {
     return sctp;
   }
 
-  async setLocalDescription(sessionDescription: {
+  async setLocalDescription(sessionDescription?: {
     type: "offer" | "answer";
     sdp: string;
   }): Promise<SessionDescription> {
+    // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription#type
+    sessionDescription =
+      sessionDescription ??
+      (["stable", "have-local-offer", "have-remote-pranswer"].includes(
+        this.signalingState,
+      )
+        ? await this.createOffer()
+        : await this.createAnswer());
+
     // # parse and validate description
     const description = SessionDescription.parse(sessionDescription.sdp);
     description.type = sessionDescription.type;

--- a/packages/webrtc/tests/integrate/perfectNegotiation.test.ts
+++ b/packages/webrtc/tests/integrate/perfectNegotiation.test.ts
@@ -1,0 +1,56 @@
+import { RTCPeerConnection } from "../../src";
+import { setupPerfectNegotiation } from "./perfectNegotiation";
+
+describe("perfect negotiation", () => {
+  it("perfect negotiation pattern", async () =>
+    new Promise<void>((done) => {
+      // Create two peer connections
+      const pc1 = new RTCPeerConnection();
+      const pc2 = new RTCPeerConnection();
+
+      pc2.onDataChannel.subscribe((channel) => {
+        channel.onMessage.subscribe((data) => {
+          expect(data.toString()).toBe("hello");
+          done();
+        });
+      });
+      const dc = pc1.createDataChannel("chat", { protocol: "bob" });
+
+      dc.stateChanged.subscribe((state) => {
+        if (state === "open") {
+          dc.send(Buffer.from("hello"));
+        }
+      });
+
+      const signaling1to2 = {
+        send: (data) => {
+          setTimeout(() => signaling2to1.onMessageCallback(data), 0);
+        },
+        onMessage: (callback) => {
+          signaling1to2.onMessageCallback = callback;
+        },
+        onMessageCallback: (data: any) => {},
+      };
+
+      const signaling2to1 = {
+        send: (data) => {
+          setTimeout(() => signaling1to2.onMessageCallback(data), 0);
+        },
+        onMessage: (callback) => {
+          signaling2to1.onMessageCallback = callback;
+        },
+        onMessageCallback: (data: any) => {},
+      };
+
+      setupPerfectNegotiation({
+        pc: pc1,
+        polite: true,
+        signaling: signaling1to2,
+      });
+      setupPerfectNegotiation({
+        pc: pc2,
+        polite: false,
+        signaling: signaling2to1,
+      });
+    }));
+});

--- a/packages/webrtc/tests/integrate/perfectNegotiation.ts
+++ b/packages/webrtc/tests/integrate/perfectNegotiation.ts
@@ -1,0 +1,137 @@
+import type {
+  RTCIceCandidate,
+  RTCPeerConnection,
+  RTCSessionDescription,
+} from "../../src";
+
+// https://w3c.github.io/webrtc-pc/#perfect-negotiation-example
+
+export type SignalingMessagePayload =
+  | {
+      type: "description";
+      description: RTCSessionDescription;
+    }
+  | {
+      type: "candidate";
+      candidate: RTCIceCandidate;
+    };
+
+/**
+ * Abstraction of signaling channel
+ */
+interface SignalingChannel {
+  send: (data: SignalingMessagePayload) => void;
+  onMessage: (callback: (data: SignalingMessagePayload) => void) => void;
+}
+
+/**
+ * Configuration object for Perfect Negotiation setup
+ */
+interface PerfectNegotiationOptions {
+  /** Peer connection */
+  pc: RTCPeerConnection;
+  /** Whether this peer is polite */
+  polite: boolean;
+  /** Signaling channel */
+  signaling: SignalingChannel;
+}
+
+/**
+ * Setup function implementing WebRTC Perfect Negotiation pattern
+ * @param options Configuration object for Perfect Negotiation setup
+ * @returns void
+ */
+export function setupPerfectNegotiation(
+  options: PerfectNegotiationOptions,
+): void {
+  const { pc, polite, signaling } = options;
+
+  // State management variables
+  let makingOffer = false;
+  let ignoreOffer = false;
+  let srdAnswerPending = false;
+
+  const handleSignalingMessage = async (message: SignalingMessagePayload) => {
+    try {
+      if (message.type === "description") {
+        const { description } = message;
+        // Detection and handling of Glare
+        const isStable =
+          pc.signalingState === "stable" ||
+          (pc.signalingState === "have-local-offer" && srdAnswerPending);
+
+        ignoreOffer =
+          description.type === "offer" && !polite && (makingOffer || !isStable);
+
+        if (ignoreOffer) {
+          return;
+        }
+
+        srdAnswerPending = description.type === "answer";
+
+        // Set remote description
+        await pc.setRemoteDescription(description);
+
+        srdAnswerPending = false;
+
+        // Generate and send answer to offer
+        if (description.type === "offer") {
+          await pc.setLocalDescription();
+
+          if (pc.localDescription) {
+            send({ type: "description", description: pc.localDescription });
+          } else {
+            console.error("Local description is null");
+          }
+        } else if (description.type === "answer") {
+          // end
+        }
+      } else if (message.type === "candidate") {
+        try {
+          await pc.addIceCandidate(message.candidate);
+        } catch (e) {
+          // Ignore errors for ICE candidates during ignoreOffer
+          if (!ignoreOffer) throw e;
+        }
+      }
+    } catch (e) {
+      console.error("Error in signaling message handling", e);
+    }
+  };
+
+  const send = (data: SignalingMessagePayload) => {
+    signaling.send(data);
+  };
+
+  // ICE candidate processing
+  pc.onicecandidate = ({ candidate }) => {
+    if (!candidate) {
+      return;
+    }
+    send({ type: "candidate", candidate });
+  };
+
+  // Handling when negotiation is needed
+  pc.onnegotiationneeded = async () => {
+    try {
+      makingOffer = true;
+
+      // Set local description
+      await pc.setLocalDescription();
+
+      // Send offer
+      if (pc.localDescription) {
+        send({ type: "description", description: pc.localDescription });
+      } else {
+        console.error("Local description is null");
+      }
+    } catch (e) {
+      console.error("Negotiation needed failed", e);
+    } finally {
+      makingOffer = false;
+    }
+  };
+
+  // Processing signaling messages
+  signaling.onMessage(handleSignalingMessage);
+}


### PR DESCRIPTION

The sessionDescription argument of setLocalDescription has been optional for some time.
[Referencing MDN, a new offer or answer is created and set accordingly.](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription#sessiondescription)
This approach is used in the “Perfect Negotiation” example of WebRTC.

https://webrtc.github.io/samples/src/content/peerconnection/perfect-negotiation/
https://w3c.github.io/webrtc-pc/#perfect-negotiation-example