### PR TITLE
chore: remove lodash.mergeWith, remove lodash as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -908,13 +908,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/multicast-dns": {
       "version": "7.2.4",
       "dev": true,
@@ -2438,10 +2431,6 @@
         "uc.micro": "^2.0.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
@@ -3862,7 +3851,6 @@
         "@noble/curves": "^1.8.1",
         "@peculiar/x509": "^1.12.3",
         "@shinyoshiaki/binary-data": "^0.6.1",
-        "lodash": "^4.17.21",
         "tweetnacl": "^1.0.3"
       },
       "engines": {
@@ -3879,12 +3867,10 @@
         "fast-deep-equal": "^3.1.3",
         "int64-buffer": "1.1.0",
         "ip": "^2.0.1",
-        "lodash": "^4.17.21",
         "multicast-dns": "^7.2.5"
       },
       "devDependencies": {
         "@types/ip": "^1.1.3",
-        "@types/lodash": "^4.17.15",
         "@types/multicast-dns": "^7.2.4"
       }
     },
@@ -3912,11 +3898,7 @@
       "license": "MIT",
       "dependencies": {
         "@shinyoshiaki/jspack": "^0.0.6",
-        "lodash": "^4.17.21",
         "turbo-crc32": "^1.0.1"
-      },
-      "devDependencies": {
-        "@types/lodash": "^4.17.15"
       },
       "engines": {
         "node": ">=10"
@@ -3939,7 +3921,6 @@
         "debug": "^4.4.0",
         "int64-buffer": "1.1.0",
         "ip": "^2.0.1",
-        "lodash": "^4.17.21",
         "mp4box": "^0.5.3",
         "multicast-dns": "^7.2.5",
         "turbo-crc32": "^1.0.1",
@@ -3949,9 +3930,6 @@
         "werift-ice": "*",
         "werift-rtp": "*",
         "werift-sctp": "*"
-      },
-      "devDependencies": {
-        "@types/lodash": "^4.17.15"
       },
       "engines": {
         "node": ">=16"

--- a/packages/dtls/package.json
+++ b/packages/dtls/package.json
@@ -34,7 +34,6 @@
     "@noble/curves": "^1.8.1",
     "@peculiar/x509": "^1.12.3",
     "@shinyoshiaki/binary-data": "^0.6.1",
-    "lodash": "^4.17.21",
     "tweetnacl": "^1.0.3"
   },
   "engines": {

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -35,12 +35,10 @@
     "fast-deep-equal": "^3.1.3",
     "int64-buffer": "1.1.0",
     "ip": "^2.0.1",
-    "lodash": "^4.17.21",
     "multicast-dns": "^7.2.5"
   },
   "devDependencies": {
     "@types/ip": "^1.1.3",
-    "@types/lodash": "^4.17.15",
     "@types/multicast-dns": "^7.2.4"
   }
 }

--- a/packages/sctp/package.json
+++ b/packages/sctp/package.json
@@ -30,11 +30,7 @@
   },
   "dependencies": {
     "@shinyoshiaki/jspack": "^0.0.6",
-    "lodash": "^4.17.21",
     "turbo-crc32": "^1.0.1"
-  },
-  "devDependencies": {
-    "@types/lodash": "^4.17.15"
   },
   "engines": {
     "node": ">=10"

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -60,7 +60,6 @@
     "debug": "^4.4.0",
     "int64-buffer": "1.1.0",
     "ip": "^2.0.1",
-    "lodash": "^4.17.21",
     "mp4box": "^0.5.3",
     "multicast-dns": "^7.2.5",
     "turbo-crc32": "^1.0.1",
@@ -70,9 +69,6 @@
     "werift-ice": "*",
     "werift-rtp": "*",
     "werift-sctp": "*"
-  },
-  "devDependencies": {
-    "@types/lodash": "^4.17.15"
   },
   "engines": {
     "node": ">=16"

--- a/packages/webrtc/src/utils.ts
+++ b/packages/webrtc/src/utils.ts
@@ -2,7 +2,6 @@
 import { createHash } from "crypto";
 import { createSocket } from "dgram";
 
-import mergeWith from "lodash/mergeWith.js";
 import { performance } from "perf_hooks";
 
 import {
@@ -142,17 +141,37 @@ export class MediaStreamTrackFactory {
       udp.removeListener("message", onMessage);
       try {
         udp.close();
-      } catch (error) {}
+      } catch (error) { }
     };
 
     return [track, port, dispose] as const;
   }
 }
 
-export const deepMerge = <T>(dst: T, src: T) =>
-  mergeWith(dst, src, (obj, src) => {
-    if (!(src == undefined)) {
+export const deepMerge = <T>(dst: T, src: T) => {
+  if (!dst || typeof dst !== 'object') {
+    if (src !== null && typeof src === 'object') {
       return src;
+    } else {
+      return dst;
     }
-    return obj;
-  });
+  }
+
+  if (!src || typeof src !== 'object') {
+    if (src == undefined) {
+      return dst;
+    }
+    return src;
+  }
+
+  for (const key in src) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) {
+      const sourceValue = src[key];
+
+      if (sourceValue != undefined) {
+        dst[key] = sourceValue;
+      }
+    }
+  }
+  return dst;
+}

--- a/packages/webrtc/src/utils.ts
+++ b/packages/webrtc/src/utils.ts
@@ -148,6 +148,11 @@ export class MediaStreamTrackFactory {
   }
 }
 
+/**
+ * Merge two objects. If a property value in the source object is undefined or
+ * when casted is equal to undefined (== undefined), then it will not overwrite
+ * the value of the property in the destination object.
+ */
 export const deepMerge = <T>(dst: T, src: T) => {
   if (!dst || typeof dst !== 'object') {
     if (src !== null && typeof src === 'object') {

--- a/packages/webrtc/tests/utils.test.ts
+++ b/packages/webrtc/tests/utils.test.ts
@@ -1,4 +1,5 @@
 import { parseIceServers } from "../src";
+import { deepMerge } from "../src";
 import type { RTCIceServer } from "../src/peerConnection";
 
 describe("utils", () => {
@@ -44,6 +45,81 @@ describe("utils", () => {
       expect(turnServer).toEqual(["turn.l.google.com", 19302]);
       expect(turnUsername).toBe("username");
       expect(turnPassword).toBe("credential");
+    });
+  });
+
+  describe('deepMerge', () => {
+    test('merges two objects', () => {
+      const obj1 = { a: 1, b: { c: 2, d: 3 } };
+      const obj2 = { b: { c: 20, e: 5 }, f: 6 };
+      const result = deepMerge(obj1, obj2 as any);
+      expect(result).toEqual({ a: 1, b: { c: 20, e: 5 }, f: 6 });
+    });
+
+    test('does not overwrite with undefined', () => {
+      const obj1 = { a: 1, b: 2 };
+      const obj2 = { a: undefined, b: 3 };
+      const result = deepMerge(obj1, obj2 as any);
+      expect(result).toEqual({ a: 1, b: 3 });
+    });
+
+    test('handles nested objects', () => {
+      const obj1 = { a: { b: { c: 1 } } };
+      const obj2 = { a: { b: { d: 2 }, e: 3 } };
+      const result = deepMerge(obj1, obj2 as any);
+      expect(result).toEqual({ a: { b: { d: 2 }, e: 3 } });
+    });
+
+    test('arrays are replaced, not merged', () => {
+      const obj1 = { a: [1, 2, 3], b: { c: [4, 5] } };
+      const obj2 = { a: [6, 7], b: { c: [8] } };
+      const result = deepMerge(obj1, obj2);
+      expect(result).toEqual({ a: [6, 7], b: { c: [8] } });
+    });
+
+    test('handles non-object inputs accordingly', () => {
+      expect(deepMerge(null as any, { a: 1 })).toEqual({ a: 1 });
+      expect(deepMerge({ a: 1 }, null as any)).toEqual({ a: 1 });
+      // lodash mergeWith treats non-objects as Datatype Objects
+      // and assigns attributes to them, which makes no sense
+      // following test would fail, as it would expect
+      // the result equal to Object(42) with attribute 'a' = 1
+      expect(deepMerge(42 as any, { a: 1 })).toEqual({ a: 1 });
+      expect(deepMerge({ a: 1 }, 42 as any)).toEqual(42);
+    });
+
+    test('merges complex nested structures', () => {
+      const obj1 = { a: { b: 1, c: { d: 2 } }, e: 3 };
+      const obj2 = { a: { c: { f: 4 } }, g: 5 };
+      const result = deepMerge(obj1, obj2 as any);
+      expect(result).toEqual({ a: { c: { f: 4 } }, e: 3, g: 5 });
+    });
+
+    test('Date objects are replaced, not merged', () => {
+      const date1 = new Date('2020-01-01');
+      const date2 = new Date('2021-01-01');
+      const obj1 = { a: date1 };
+      const obj2 = { a: date2 };
+      const result = deepMerge(obj1, obj2);
+      expect(result).toEqual({ a: date2 });
+    });
+
+    test('functions are replaced, not merged', () => {
+      const func1 = () => 1;
+      const func2 = () => 2;
+      const obj1 = { a: func1 };
+      const obj2 = { a: func2 };
+      const result = deepMerge(obj1, obj2);
+      expect(result.a).toBe(func2);
+    });
+
+    test('symbol properties are ignored', () => {
+      const sym1 = Symbol('a');
+      const sym2 = Symbol('b');
+      const obj1 = { [sym1]: 1 };
+      const obj2 = { [sym2]: 2 };
+      const result = deepMerge(obj1, obj2 as any);
+      expect(result).toEqual({ [sym1]: 1 });
     });
   });
 });


### PR DESCRIPTION
This is the last PR regarding lodash.

deepMerge is actually not a deepMerge. Its more like merge but ignore attributes with a value which when transformed is equal == undefined.