### PR TITLE
Export `stats` module from `media/index.ts`

### DIFF
--- a/packages/webrtc/src/media/index.ts
+++ b/packages/webrtc/src/media/index.ts
@@ -6,5 +6,6 @@ export * from "./router";
 export * from "./rtpReceiver";
 export * from "./rtpSender";
 export * from "./rtpTransceiver";
+export * from "./stats";
 export * from "../transceiverManager";
 export * from "./track";


### PR DESCRIPTION
I tried to import various stats-related types in my project, but it turns out that they're not `export`ed from `media/index.ts`. The types defined in `stats.ts` are all `export`ed already, so it looks like this is an oversight rather than a design decision.