### PR TITLE
fix circular imports in RtcpPacketConverter

### DIFF
--- a/packages/rtp/src/rtcp/header.ts
+++ b/packages/rtp/src/rtcp/header.ts
@@ -27,6 +27,22 @@ export class RtcpHeader {
     Object.assign(this, props);
   }
 
+  static serialize(
+    type: number,
+    count: number,
+    payload: Buffer,
+    length: number,
+  ) {
+    const header = new RtcpHeader({
+      type,
+      count,
+      version: 2,
+      length,
+    });
+    const buf = header.serialize();
+    return Buffer.concat([buf, payload]);
+  }
+
   serialize() {
     const v_p_rc = new BitWriter(8);
     v_p_rc.set(2, 0, this.version);

--- a/packages/rtp/src/rtcp/psfb/index.ts
+++ b/packages/rtp/src/rtcp/psfb/index.ts
@@ -1,6 +1,5 @@
 import { debug } from "../../imports/common";
-import type { RtcpHeader } from "../header";
-import { RtcpPacketConverter } from "../rtcp";
+import { RtcpHeader } from "../header";
 import { FullIntraRequest } from "./fullIntraRequest";
 import { PictureLossIndication } from "./pictureLossIndication";
 import { ReceiverEstimatedMaxBitrate } from "./remb";
@@ -24,7 +23,7 @@ export class RtcpPayloadSpecificFeedback {
 
   serialize() {
     const payload = this.feedback.serialize();
-    return RtcpPacketConverter.serialize(
+    return RtcpHeader.serialize(
       this.type,
       this.feedback.count,
       payload,

--- a/packages/rtp/src/rtcp/rr.ts
+++ b/packages/rtp/src/rtcp/rr.ts
@@ -1,5 +1,5 @@
 import { bufferReader, bufferWriter } from "../../../common/src";
-import { RtcpPacketConverter } from "./rtcp";
+import { RtcpHeader } from "./header";
 
 export class RtcpRrPacket {
   ssrc = 0;
@@ -17,7 +17,7 @@ export class RtcpRrPacket {
       payload,
       ...this.reports.map((report) => report.serialize()),
     ]);
-    return RtcpPacketConverter.serialize(
+    return RtcpHeader.serialize(
       RtcpRrPacket.type,
       this.reports.length,
       payload,

--- a/packages/rtp/src/rtcp/rtcp.ts
+++ b/packages/rtp/src/rtcp/rtcp.ts
@@ -16,22 +16,6 @@ export type RtcpPacket =
   | RtcpTransportLayerFeedback;
 
 export class RtcpPacketConverter {
-  static serialize(
-    type: number,
-    count: number,
-    payload: Buffer,
-    length: number,
-  ) {
-    const header = new RtcpHeader({
-      type,
-      count,
-      version: 2,
-      length,
-    });
-    const buf = header.serialize();
-    return Buffer.concat([buf, payload]);
-  }
-
   static deSerialize(data: Buffer) {
     let pos = 0;
     const packets: RtcpPacket[] = [];

--- a/packages/rtp/src/rtcp/rtpfb/const.ts
+++ b/packages/rtp/src/rtcp/rtpfb/const.ts
@@ -1,0 +1,1 @@
+export const RtcpTransportLayerFeedbackType = 205;

--- a/packages/rtp/src/rtcp/rtpfb/index.ts
+++ b/packages/rtp/src/rtcp/rtpfb/index.ts
@@ -1,5 +1,6 @@
 import { debug } from "../../imports/common";
 import type { RtcpHeader } from "../header";
+import { RtcpTransportLayerFeedbackType } from "./const";
 import { GenericNack } from "./nack";
 import { TransportWideCC } from "./twcc";
 
@@ -20,7 +21,7 @@ const log = debug("werift-rtp:packages/rtp/rtcp/rtpfb/index");
 type Feedback = GenericNack | TransportWideCC;
 
 export class RtcpTransportLayerFeedback {
-  static readonly type = 205;
+  static readonly type = RtcpTransportLayerFeedbackType;
   readonly type = RtcpTransportLayerFeedback.type;
   feedback!: Feedback;
   header!: RtcpHeader;

--- a/packages/rtp/src/rtcp/rtpfb/nack.ts
+++ b/packages/rtp/src/rtcp/rtpfb/nack.ts
@@ -1,6 +1,6 @@
-import { RtcpTransportLayerFeedback } from ".";
 import { bufferReader, bufferWriter } from "../../../../common/src";
 import { RtcpHeader } from "../header";
+import { RtcpTransportLayerFeedbackType } from "./const";
 
 // 0                   1                   2                   3
 // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -31,7 +31,7 @@ export class GenericNack {
     Object.assign(this, props);
     if (!this.header) {
       this.header = new RtcpHeader({
-        type: RtcpTransportLayerFeedback.type,
+        type: RtcpTransportLayerFeedbackType,
         count: this.count,
         version: 2,
       });

--- a/packages/rtp/src/rtcp/sdes.ts
+++ b/packages/rtp/src/rtcp/sdes.ts
@@ -1,6 +1,5 @@
 import { bufferWriter } from "../../../common/src";
-import type { RtcpHeader } from "./header";
-import { RtcpPacketConverter } from "./rtcp";
+import { RtcpHeader } from "./header";
 
 export class RtcpSourceDescriptionPacket {
   static readonly type = 202;
@@ -21,7 +20,7 @@ export class RtcpSourceDescriptionPacket {
     let payload = Buffer.concat(this.chunks.map((chunk) => chunk.serialize()));
     while (payload.length % 4)
       payload = Buffer.concat([payload, Buffer.from([0])]);
-    return RtcpPacketConverter.serialize(
+    return RtcpHeader.serialize(
       this.type,
       this.chunks.length,
       payload,

--- a/packages/rtp/src/rtcp/sr.ts
+++ b/packages/rtp/src/rtcp/sr.ts
@@ -1,6 +1,6 @@
 import { bufferReader, bufferWriter } from "../../../common/src";
+import { RtcpHeader } from "./header";
 import { RtcpReceiverInfo } from "./rr";
-import { RtcpPacketConverter } from "./rtcp";
 
 // https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1
 //         0                   1                   2                   3
@@ -66,7 +66,7 @@ export class RtcpSrPacket {
       payload,
       ...this.reports.map((report) => report.serialize()),
     ]);
-    return RtcpPacketConverter.serialize(
+    return RtcpHeader.serialize(
       RtcpSrPacket.type,
       this.reports.length,
       payload,

--- a/packages/rtp/tests/rtcp/rtcp.test.ts
+++ b/packages/rtp/tests/rtcp/rtcp.test.ts
@@ -1,4 +1,4 @@
-import { PictureLossIndication, RtcpPayloadSpecificFeedback } from "../../src";
+import { PictureLossIndication, RtcpHeader, RtcpPayloadSpecificFeedback } from "../../src";
 import { RtcpRrPacket } from "../../src/rtcp/rr";
 import { RtcpPacketConverter } from "../../src/rtcp/rtcp";
 import { RtcpSrPacket } from "../../src/rtcp/sr";
@@ -57,7 +57,7 @@ describe("rtcp/rtcp", () => {
   });
 
   test("should fail", () => {
-    const rtcp = RtcpPacketConverter.serialize(
+    const rtcp = RtcpHeader.serialize(
       RtcpPayloadSpecificFeedback.type,
       PictureLossIndication.count,
       Buffer.from([0]),


### PR DESCRIPTION
The circular import for RtcpPacketConverter is triggering warnings in my bundler, though it works fine. I resolved this.