### PR TITLE
dtls fallbck

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -401,7 +401,7 @@ export class RTCPeerConnection extends EventTarget {
         media: this._localDescription.media[0],
         transceiver: this.transceiverManager
           .getTransceivers()
-          .find((t) => t.dtlsTransport.iceTransport.id === iceTransport.id),
+          .find((t) => t?.dtlsTransport?.iceTransport.id === iceTransport.id),
         sctpTransport:
           this.sctpTransport?.dtlsTransport.iceTransport.id === iceTransport.id
             ? this.sctpTransport

--- a/packages/webrtc/src/sdpManager.ts
+++ b/packages/webrtc/src/sdpManager.ts
@@ -476,10 +476,21 @@ export class SDPManager {
     transceivers: RTCRtpTransceiver[],
     sctpTransport?: { dtlsTransport: RTCDtlsTransport; mid?: string },
   ) {
+    const transceiverByMLineIndex = new Map(
+      transceivers.map((transceiver) => [transceiver?.mLineIndex, transceiver]),
+    );
+    const fallbackDtlsTransport =
+      transceivers.find((transceiver) => transceiver?.dtlsTransport)?.dtlsTransport ??
+      sctpTransport?.dtlsTransport;
     description.media
       .filter((m) => ["audio", "video"].includes(m.kind))
       .forEach((m, i) => {
-        this.addTransportDescription(m, transceivers[i].dtlsTransport);
+        const transceiver = transceiverByMLineIndex.get(i) ?? transceivers[i];
+        const dtlsTransport = transceiver?.dtlsTransport ?? fallbackDtlsTransport;
+        if (!dtlsTransport) {
+          throw new Error(`dtls transport not found for media index ${i}`);
+        }
+        this.addTransportDescription(m, dtlsTransport);
       });
     const sctpMedia = description.media.find((m) => m.kind === "application");
     if (sctpTransport && sctpMedia) {

--- a/packages/webrtc/src/secureTransportManager.ts
+++ b/packages/webrtc/src/secureTransportManager.ts
@@ -63,7 +63,7 @@ export class SecureTransportManager {
 
   get dtlsTransports() {
     const transports = [
-      ...this.transceiverManager.getTransceivers().map((t) => t.dtlsTransport),
+      ...this.transceiverManager.getTransceivers().map((t) => t?.dtlsTransport),
       this.sctpManager.sctpTransport?.dtlsTransport,
     ].filter((t) => t != undefined);
 


### PR DESCRIPTION
This pull request improves the robustness and reliability of the WebRTC transport and SDP handling code by adding more defensive checks for potentially undefined properties and improving how DTLS transports are resolved. The main focus is on preventing runtime errors when dealing with optional or missing transceiver and transport properties.

**Defensive property access and null safety:**

* Updated all usages of `dtlsTransport` and related properties in `RTCPeerConnection`, `SecureTransportManager`, and `SDPManager` to use optional chaining, preventing errors if a transceiver or its transport is undefined. [[1]](diffhunk://#diff-3bc78b20b7ffa3340be89f975e4457f6b8a11a11f67789d5554286e6ab0780caL404-R404) [[2]](diffhunk://#diff-6fe1a4f2d8bc6c90d30d69679447386a613dbc29a8a4d160edd24eec0f3de401L66-R66)

**SDP and DTLS transport handling improvements:**

* In `SDPManager`, introduced a mapping of transceivers by `mLineIndex` and a fallback mechanism for selecting a DTLS transport if one is missing, throwing an explicit error if no suitable transport is found. This ensures more reliable SDP processing and clearer error reporting.