### PR TITLE
fix(webrtc): handle data channel ID 0 correctly

### DIFF
--- a/packages/webrtc/src/transport/sctp.ts
+++ b/packages/webrtc/src/transport/sctp.ts
@@ -237,7 +237,7 @@ export class RTCSctpTransport {
   }
 
   dataChannelOpen(channel: RTCDataChannel) {
-    if (channel.id) {
+    if (channel.id !== undefined) {
       if (this.dataChannels[channel.id])
         throw new Error(
           `Data channel with ID ${channel.id} already registered`,
@@ -405,7 +405,7 @@ export class RTCSctpTransport {
         this.sctp.reconfigQueue = this.sctp.reconfigQueue.filter(
           (streamId) => streamId !== channel.id,
         );
-        if (channel.id) {
+        if (channel.id !== undefined) {
           delete this.dataChannels[channel.id];
         }
         channel.setReadyState("closed");


### PR DESCRIPTION
## Bug Description

Data channel with ID 0 fails to register and leaks on close because 0 is falsy in JavaScript.

## Root Cause

SCTP stream IDs start at 0. The code used if (channel.id) which treats 0 as false, causing:
- dataChannelOpen(): ID 0 channels never registered in this.dataChannels
- dataChannelClose(): ID 0 channels never removed from this.dataChannels (memory leak)

## Fix

Replace truthy check with explicit !== undefined check in both dataChannelOpen() and dataChannelClose() methods.

## Changes

- packages/webrtc/src/transport/sctp.ts: Fixed 2 occurrences

## Verification

- Built successfully: npm run build
- Type-check passed: npx tsc --noEmit in packages/webrtc