### PR TITLE
chore: narrow RTCDtlsTransport config type

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -1121,6 +1121,17 @@ export class RTCPeerConnection extends EventTarget {
   }
 }
 
+export type DebugConfig = Partial<{
+  /**% */
+  inboundPacketLoss: number;
+  /**% */
+  outboundPacketLoss: number;
+  /**ms */
+  receiverReportDelay: number;
+  disableSendNack: boolean;
+  disableRecvRetransmit: boolean;
+}>;
+
 export interface PeerConfig {
   codecs: Partial<{
     /**
@@ -1167,16 +1178,7 @@ export interface PeerConfig {
   rtcpMuxPolicy: "require";
   iceCandidatePoolSize: number;
   certificates: RTCCertificate[];
-  debug: Partial<{
-    /**% */
-    inboundPacketLoss: number;
-    /**% */
-    outboundPacketLoss: number;
-    /**ms */
-    receiverReportDelay: number;
-    disableSendNack: boolean;
-    disableRecvRetransmit: boolean;
-  }>;
+  debug: DebugConfig;
   midSuffix: boolean;
   /** Advertised local SCTP max-message-size in SDP. Use 0 for unlimited. */
   maxMessageSize: number;

--- a/packages/webrtc/src/transport/dtls.ts
+++ b/packages/webrtc/src/transport/dtls.ts
@@ -40,7 +40,7 @@ import {
   generateStatsId,
   getStatsTimestamp,
 } from "../media/stats";
-import type { PeerConfig } from "../peerConnection";
+import type { DebugConfig } from "../peerConnection";
 import {
   fingerprint,
   isDtls,
@@ -112,7 +112,7 @@ export class RTCDtlsTransport implements DtlsTransportStats {
   private remoteParameters?: RTCDtlsParameters;
 
   constructor(
-    readonly config: PeerConfig,
+    readonly config: { debug?: DebugConfig },
     readonly iceTransport: RTCIceTransport,
     public localCertificate?: RTCCertificate,
     private readonly srtpProfiles: SrtpProfile[] = [],
@@ -212,8 +212,8 @@ export class RTCDtlsTransport implements DtlsTransportStats {
       }
       this.dtls.onData.subscribe((buf) => {
         if (
-          this.config.debug.inboundPacketLoss &&
-          this.config.debug.inboundPacketLoss / 100 < Math.random()
+          this.config.debug?.inboundPacketLoss &&
+          this.config.debug?.inboundPacketLoss / 100 < Math.random()
         ) {
           return;
         }
@@ -354,8 +354,8 @@ export class RTCDtlsTransport implements DtlsTransportStats {
 
     this.iceTransport.connection.onData.subscribe((data) => {
       if (
-        this.config.debug.inboundPacketLoss &&
-        this.config.debug.inboundPacketLoss / 100 < Math.random()
+        this.config.debug?.inboundPacketLoss &&
+        this.config.debug?.inboundPacketLoss / 100 < Math.random()
       ) {
         return;
       }
@@ -420,8 +420,8 @@ export class RTCDtlsTransport implements DtlsTransportStats {
 
   readonly sendData = async (data: Buffer) => {
     if (
-      this.config.debug.outboundPacketLoss &&
-      this.config.debug.outboundPacketLoss / 100 < Math.random()
+      this.config.debug?.outboundPacketLoss &&
+      this.config.debug?.outboundPacketLoss / 100 < Math.random()
     ) {
       return;
     }
@@ -437,8 +437,8 @@ export class RTCDtlsTransport implements DtlsTransportStats {
       const enc = this.srtp.encrypt(payload, header);
 
       if (
-        this.config.debug.outboundPacketLoss &&
-        this.config.debug.outboundPacketLoss / 100 < Math.random()
+        this.config.debug?.outboundPacketLoss &&
+        this.config.debug?.outboundPacketLoss / 100 < Math.random()
       ) {
         return enc.length;
       }
@@ -460,8 +460,8 @@ export class RTCDtlsTransport implements DtlsTransportStats {
     const enc = this.srtcp.encrypt(payload);
 
     if (
-      this.config.debug.outboundPacketLoss &&
-      this.config.debug.outboundPacketLoss / 100 < Math.random()
+      this.config.debug?.outboundPacketLoss &&
+      this.config.debug?.outboundPacketLoss / 100 < Math.random()
     ) {
       return enc.length;
     }


### PR DESCRIPTION
Extract a `DebugConfig` type from the inline `Partial<{...}>` in `PeerConfig`, and narrow `RTCDtlsTransport`'s constructor to accept `{ debug?: DebugConfig }` instead of the full `PeerConfig`.

## Why

`RTCDtlsTransport` only ever reads two paths from its config:

- `this.config.debug.inboundPacketLoss` (lines 188, 330)
- `this.config.debug.outboundPacketLoss` (lines 396, 413, 436)

But its constructor is typed to accept the entire `PeerConfig` interface — 25+ fields, most of which are irrelevant to DTLS. Anyone constructing `RTCDtlsTransport` directly (for example, in WebRTC Direct mode where you bypass `RTCPeerConnection`) must either provide a full `PeerConfig` or use a type escape hatch like `as any`.

## What

1. **Extract `DebugConfig`** — a named type for the inline partial that was inside `PeerConfig.debug`. Reuse it in `PeerConfig` so existing callers are unaffected.

2. **Narrow `RTCDtlsTransport`'s constructor config** — from `config: PeerConfig` to `config: { debug?: DebugConfig }`. This is the minimal type the class actually needs.

3. **Add optional chaining** — `this.config.debug?.inboundPacketLoss` instead of `this.config.debug.inboundPacketLoss`. Since `debug` is now optional, the code handles `undefined` gracefully (same runtime behaviour: when `debug` is absent, packet loss simulation is disabled).

## Existing callers are unaffected

- `SecureTransportManager.createTransport()` passes `this.config` (a `PeerConfig`) — `PeerConfig` has `debug: DebugConfig` (required), which structurally satisfies `debug?: DebugConfig` (optional)
- Tests pass `defaultPeerConfig` (also `PeerConfig`) — same story
- No runtime changes: the truthy guards behave identically when `debug` is `{}`

## Benefits

- **No more `as any`** when constructing `RTCDtlsTransport` directly — `{ debug: {} }` or even `{}` type-checks without escapes
- **Self-documenting** — the constructor parameter type communicates exactly what it depends on
- **Backward compatible** — all existing callers compile without changes

## Examples

```ts
// Before — requires as any or a full PeerConfig
new RTCDtlsTransport({ debug: {} } as any, iceTransport, cert, profiles);

// After — just works
new RTCDtlsTransport({ debug: {} }, iceTransport, cert, profiles);
new RTCDtlsTransport({}, iceTransport, cert, profiles);
new RTCDtlsTransport({ debug: { inboundPacketLoss: 50 } }, iceTransport, cert, profiles);
```

---

*This PR was generated by Kimi K2.6 with human oversight.*