### PR TITLE
feat(dtls): add ChaCha20-Poly1305 cipher suites (RFC 7905)

### DIFF
--- a/packages/dtls/src/cipher/const.ts
+++ b/packages/dtls/src/cipher/const.ts
@@ -18,6 +18,8 @@ export type SignatureHash = {
 export const CipherSuite = {
   TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256_49195: 0xc02b, //49195,
   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_49199: 0xc02f, //49199
+  TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256_52393: 0xcca9, //52393
+  TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256_52392: 0xcca8, //52392
 } as const;
 export type CipherSuites = (typeof CipherSuite)[keyof typeof CipherSuite];
 export const CipherSuiteList: CipherSuites[] = Object.values(CipherSuite);

--- a/packages/dtls/src/cipher/create.ts
+++ b/packages/dtls/src/cipher/create.ts
@@ -8,6 +8,7 @@ import {
   createRSAKeyExchange,
 } from "./key-exchange";
 import AEADCipher from "./suites/aead";
+import AEADChaCha20Poly1305Cipher from "./suites/chacha";
 
 const cipherSuites = {
   TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: 0xc02b,
@@ -148,11 +149,59 @@ export function createCipher(cipher: number) {
         AEAD_AES_256_GCM,
         "sha384",
       );
+    case cipherSuites.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
+      return createChaCha20Poly1305Cipher(
+        cipherSuites.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+        ECDHE_RSA_KEY_EXCHANGE,
+      );
+    case cipherSuites.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
+      return createChaCha20Poly1305Cipher(
+        cipherSuites.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+        ECDHE_ECDSA_KEY_EXCHANGE,
+      );
     default:
       break;
   }
 
   return null as any as AEADCipher;
+}
+
+/**
+ * AEAD_CHACHA20_POLY1305 (RFC 7905). Uses a 32-byte key and a 12-byte fixed
+ * write IV; there is no explicit nonce on the wire (record_iv_length === 0).
+ * @param {number} id An internal id of cipher suite.
+ * @param {string} name A valid cipher suite name.
+ * @param {KeyExchange} kx Key exchange type.
+ * @param {string} hash
+ * @returns {AEADChaCha20Poly1305Cipher}
+ */
+export function createChaCha20Poly1305Cipher(
+  id: number,
+  name: string,
+  kx: KeyExchange,
+  hash = "sha256",
+) {
+  const cipher = new AEADChaCha20Poly1305Cipher();
+
+  cipher.id = id;
+  cipher.name = name;
+  cipher.kx = kx;
+  cipher.hashAlgorithm = hash;
+
+  cipher.keyLength = 32;
+  cipher.nonceLength = 12;
+
+  // RFC 7905: 12-byte fixed IV, no explicit (per-record) nonce on the wire.
+  cipher.nonceImplicitLength = 12;
+  cipher.nonceExplicitLength = 0;
+
+  cipher.ivLength = cipher.nonceImplicitLength;
+
+  cipher.authTagLength = 16;
+
+  return cipher;
 }
 
 /**

--- a/packages/dtls/src/cipher/suites/chacha.ts
+++ b/packages/dtls/src/cipher/suites/chacha.ts
@@ -1,0 +1,132 @@
+import { type CipherCCMTypes, createCipheriv, createDecipheriv } from "crypto";
+
+import { dumpBuffer, getObjectSummary } from "../../helper";
+import { debug } from "../../imports/common";
+import { prfEncryptionKeys } from "../prf";
+import { type CipherHeader, SessionType, type SessionTypes } from "./abstract";
+import AEADCipher from "./aead";
+
+const err = debug(
+  "werift-dtls : packages/dtls/src/cipher/suites/chacha.ts : err",
+);
+
+const NONCE_LENGTH = 12;
+const TAG_LENGTH = 16;
+const ALGORITHM = "chacha20-poly1305" as CipherCCMTypes;
+
+/**
+ * AEAD_CHACHA20_POLY1305 cipher for TLS/DTLS 1.2 (RFC 7905).
+ *
+ * Differs from the AES-GCM AEAD scheme in two ways:
+ *  - the per-record nonce is the 12-byte write IV XOR'd with the 64-bit
+ *    record sequence number (left-padded to 12 bytes), and
+ *  - there is no explicit nonce on the wire (record_iv_length === 0), so an
+ *    encrypted record is just ciphertext followed by the 16-byte auth tag.
+ */
+export default class AEADChaCha20Poly1305Cipher extends AEADCipher {
+  get summary() {
+    return getObjectSummary(this);
+  }
+
+  init(masterSecret: Buffer, serverRandom: Buffer, clientRandom: Buffer) {
+    const keys = prfEncryptionKeys(
+      masterSecret,
+      clientRandom,
+      serverRandom,
+      this.keyLength,
+      this.ivLength,
+      this.nonceLength,
+      this.hashAlgorithm,
+    );
+
+    this.clientWriteKey = keys.clientWriteKey;
+    this.serverWriteKey = keys.serverWriteKey;
+    this.clientNonce = keys.clientNonce;
+    this.serverNonce = keys.serverNonce;
+  }
+
+  /**
+   * RFC 7905, sec. 2: nonce = write_IV XOR (0x00000000 || seq_num).
+   * For DTLS the 64-bit sequence is the 16-bit epoch concatenated with the
+   * 48-bit record sequence number.
+   */
+  private computeNonce(fixedIv: Buffer, header: CipherHeader) {
+    const padded = Buffer.alloc(NONCE_LENGTH, 0);
+    padded.writeUInt16BE(header.epoch, 4);
+    padded.writeUIntBE(header.sequenceNumber, 6, 6);
+
+    const nonce = Buffer.alloc(NONCE_LENGTH);
+    for (let i = 0; i < NONCE_LENGTH; i += 1) {
+      nonce[i] = fixedIv[i] ^ padded[i];
+    }
+    return nonce;
+  }
+
+  encrypt(type: SessionTypes, data: Buffer, header: CipherHeader) {
+    const isClient = type === SessionType.CLIENT;
+    const fixedIv = isClient ? this.clientNonce : this.serverNonce;
+    const writeKey = isClient ? this.clientWriteKey : this.serverWriteKey;
+    if (!fixedIv || !writeKey) throw new Error();
+
+    const nonce = this.computeNonce(fixedIv, header);
+    const additionalBuffer = this.encodeAdditionalBuffer(header, data.length);
+
+    const cipher = createCipheriv(ALGORITHM, writeKey, nonce, {
+      authTagLength: TAG_LENGTH,
+    });
+
+    cipher.setAAD(additionalBuffer, {
+      plaintextLength: data.length,
+    });
+
+    const headPart = cipher.update(data);
+    const finalPart = cipher.final();
+    const authTag = cipher.getAuthTag();
+
+    // RFC 7905: no explicit nonce is transmitted.
+    return Buffer.concat([headPart, finalPart, authTag]);
+  }
+
+  decrypt(type: SessionTypes, data: Buffer, header: CipherHeader) {
+    const isClient = type === SessionType.CLIENT;
+    const fixedIv = isClient ? this.serverNonce : this.clientNonce;
+    const writeKey = isClient ? this.serverWriteKey : this.clientWriteKey;
+    if (!fixedIv || !writeKey) throw new Error();
+
+    const encrypted = data.subarray(0, data.length - TAG_LENGTH);
+    const authTag = data.subarray(data.length - TAG_LENGTH);
+
+    const nonce = this.computeNonce(fixedIv, header);
+    const additionalBuffer = this.encodeAdditionalBuffer(
+      header,
+      encrypted.length,
+    );
+
+    const decipher = createDecipheriv(ALGORITHM, writeKey, nonce, {
+      authTagLength: TAG_LENGTH,
+    });
+
+    decipher.setAuthTag(authTag);
+    decipher.setAAD(additionalBuffer, {
+      plaintextLength: encrypted.length,
+    });
+
+    const headPart = decipher.update(encrypted);
+    try {
+      const finalPart = decipher.final();
+      return finalPart.length > 0
+        ? Buffer.concat([headPart, finalPart])
+        : headPart;
+    } catch (error) {
+      err(
+        "decrypt failed",
+        error,
+        type,
+        dumpBuffer(data),
+        header,
+        this.summary,
+      );
+      throw error;
+    }
+  }
+}

--- a/packages/dtls/tests/cipher/chacha.test.ts
+++ b/packages/dtls/tests/cipher/chacha.test.ts
@@ -1,0 +1,93 @@
+import { CipherSuite, CipherSuiteList } from "../../src/cipher/const";
+import { createCipher } from "../../src/cipher/create";
+import { SessionType } from "../../src/cipher/suites/abstract";
+import AEADChaCha20Poly1305Cipher from "../../src/cipher/suites/chacha";
+
+const CHACHA20_RSA = 0xcca8;
+const CHACHA20_ECDSA = 0xcca9;
+
+// Deterministic key material; values are arbitrary but shared by both peers so
+// they derive identical write keys/IVs (as they would after a real handshake).
+const masterSecret = Buffer.alloc(48, 0x0b);
+const clientRandom = Buffer.alloc(32, 0x01);
+const serverRandom = Buffer.alloc(32, 0x02);
+
+const header = (sequenceNumber: number) => ({
+  type: 23, // application_data
+  version: 0xfefd, // DTLS 1.2
+  epoch: 1,
+  sequenceNumber,
+});
+
+function initPair() {
+  const client = createCipher(CHACHA20_RSA) as AEADChaCha20Poly1305Cipher;
+  const server = createCipher(CHACHA20_RSA) as AEADChaCha20Poly1305Cipher;
+  client.init(masterSecret, serverRandom, clientRandom);
+  server.init(masterSecret, serverRandom, clientRandom);
+  return { client, server };
+}
+
+describe("cipher/suites/chacha", () => {
+  test("0xcca8 / 0xcca9 are offered in the ClientHello cipher list", () => {
+    expect(CipherSuiteList).toContain(CHACHA20_RSA);
+    expect(CipherSuiteList).toContain(CHACHA20_ECDSA);
+    expect(CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256_52392).toBe(
+      CHACHA20_RSA,
+    );
+  });
+
+  test("createCipher(0xcca8) returns a ChaCha20-Poly1305 cipher (RFC 7905 params)", () => {
+    const cipher = createCipher(CHACHA20_RSA) as AEADChaCha20Poly1305Cipher;
+    expect(cipher).toBeInstanceOf(AEADChaCha20Poly1305Cipher);
+    expect(cipher.keyLength).toBe(32);
+    expect(cipher.nonceLength).toBe(12);
+    expect(cipher.authTagLength).toBe(16);
+    // No explicit (per-record) nonce on the wire.
+    expect(cipher.nonceExplicitLength).toBe(0);
+  });
+
+  test("client-encrypted record round-trips through server decrypt", () => {
+    const { client, server } = initPair();
+    const plaintext = Buffer.from("the quick brown fox");
+
+    const sealed = client.encrypt(SessionType.CLIENT, plaintext, header(0));
+    // RFC 7905: ciphertext length == plaintext length, plus a 16-byte tag,
+    // with no explicit nonce prefix.
+    expect(sealed.length).toBe(plaintext.length + 16);
+
+    const opened = server.decrypt(SessionType.SERVER, sealed, header(0));
+    expect(opened).toEqual(plaintext);
+  });
+
+  test("server-encrypted record round-trips through client decrypt", () => {
+    const { client, server } = initPair();
+    const plaintext = Buffer.from("jumps over the lazy dog");
+
+    const sealed = server.encrypt(SessionType.SERVER, plaintext, header(7));
+    const opened = client.decrypt(SessionType.CLIENT, sealed, header(7));
+    expect(opened).toEqual(plaintext);
+  });
+
+  test("distinct sequence numbers produce distinct ciphertexts (nonce varies)", () => {
+    const { client } = initPair();
+    const plaintext = Buffer.from("repeated plaintext");
+
+    const a = client.encrypt(SessionType.CLIENT, plaintext, header(0));
+    const b = client.encrypt(SessionType.CLIENT, plaintext, header(1));
+    expect(a.equals(b)).toBe(false);
+  });
+
+  test("a tampered auth tag is rejected", () => {
+    const { client, server } = initPair();
+    const sealed = client.encrypt(
+      SessionType.CLIENT,
+      Buffer.from("authenticated"),
+      header(0),
+    );
+    sealed[sealed.length - 1] ^= 0xff; // flip a tag byte
+
+    expect(() =>
+      server.decrypt(SessionType.SERVER, sealed, header(0)),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the AEAD_CHACHA20_POLY1305 cipher to the DTLS 1.2 stack and offers two cipher suites in the ClientHello:

- `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256` (`0xCCA8`)
- `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` (`0xCCA9`)

Previously the DTLS client offered only the two AES-GCM suites, so it could not interoperate with peers that require ChaCha20-Poly1305 (common on mbedTLS-based and mobile/embedded endpoints, and often preferred on hardware without AES acceleration).

## Implementation

Follows RFC 7905:
- 32-byte key, 12-byte fixed write IV.
- Per-record nonce = `write_IV XOR` the left-padded 64-bit record sequence number (16-bit epoch and 48-bit sequence number).
- No explicit nonce on the wire (`record_iv_length == 0`); a record is ciphertext followed by the 16-byte tag.
- Reuses the existing PRF key expansion and the standard TLS 1.2 AEAD additional-data layout; uses Node's native `chacha20-poly1305`.

The change is additive: the new suites are appended after the existing AES-GCM suites, so default negotiation against AES-GCM peers is unchanged.

## Tests

Adds `tests/cipher/chacha.test.ts`: encrypt/decrypt round-trips in both directions, nonce variation across sequence numbers, auth-tag tamper rejection, and presence in the offered cipher list. Verified end-to-end interop against OpenSSL `s_server -cipher ECDHE-RSA-CHACHA20-POLY1305` (mutual auth) completing the handshake and negotiating `0xCCA8`.