### PR TITLE
Fix audio RED fmtp to reference the negotiated primary payload type

### DIFF
--- a/packages/webrtc/src/peerConnection.ts
+++ b/packages/webrtc/src/peerConnection.ts
@@ -460,12 +460,27 @@ export class RTCPeerConnection extends EventTarget {
         case "red":
           {
             if (codecParams.contentType === "audio") {
-              const redundant = codecParams.payloadType + 1;
-              codecParams.parameters = `${redundant}/${redundant}`;
               codecParams.payloadType = 63;
             }
           }
           break;
+      }
+    }
+
+    // audio RED redundancy must reference the primary audio codec's payload
+    // type, which is only known once every codec has one assigned. Deriving
+    // it from the RED payload type breaks when RED is not listed directly
+    // before the primary codec or when payload types are set explicitly.
+    const audioCodecs = this.config.codecs.audio || [];
+    const audioRed = audioCodecs.find((c) => c.name.toLowerCase() === "red");
+    if (audioRed && audioRed.parameters == undefined) {
+      const primary = audioCodecs.find(
+        (c) =>
+          !["red", "rtx"].includes(c.name.toLowerCase()) &&
+          c.payloadType != undefined,
+      );
+      if (primary) {
+        audioRed.parameters = `${primary.payloadType}/${primary.payloadType}`;
       }
     }
 

--- a/packages/webrtc/tests/integrate/negotiation.test.ts
+++ b/packages/webrtc/tests/integrate/negotiation.test.ts
@@ -136,5 +136,71 @@ describe("codec negotiation", () => {
 
       await Promise.all([caller.close(), callee.close()]);
     });
+
+    it("red fmtp references opus when red is listed after opus", async () => {
+      const caller = new RTCPeerConnection({
+        codecs: {
+          audio: [
+            new RTCRtpCodecParameters({
+              mimeType: "audio/opus",
+              clockRate: 48000,
+              channels: 2,
+            }),
+            new RTCRtpCodecParameters({
+              mimeType: "audio/red",
+              clockRate: 48000,
+              channels: 2,
+            }),
+          ],
+        },
+      });
+
+      const track = new MediaStreamTrack({ kind: "audio" });
+      caller.addTrack(track);
+
+      const offer = await caller.setLocalDescription(
+        await caller.createOffer(),
+      );
+      const [media] = offer.media;
+      const red = media.rtp.codecs.find((c) => c.name === "red")!;
+      const opus = media.rtp.codecs.find((c) => c.name === "opus")!;
+      expect(red.parameters).toBe(`${opus.payloadType}/${opus.payloadType}`);
+
+      await caller.close();
+    });
+
+    it("red fmtp references opus with explicit payload types", async () => {
+      const caller = new RTCPeerConnection({
+        codecs: {
+          audio: [
+            new RTCRtpCodecParameters({
+              mimeType: "audio/red",
+              clockRate: 48000,
+              channels: 2,
+              payloadType: 63,
+            }),
+            new RTCRtpCodecParameters({
+              mimeType: "audio/opus",
+              clockRate: 48000,
+              channels: 2,
+              payloadType: 111,
+            }),
+          ],
+        },
+      });
+
+      const track = new MediaStreamTrack({ kind: "audio" });
+      caller.addTrack(track);
+
+      const offer = await caller.setLocalDescription(
+        await caller.createOffer(),
+      );
+      const [media] = offer.media;
+      const red = media.rtp.codecs.find((c) => c.name === "red")!;
+      expect(red.payloadType).toBe(63);
+      expect(red.parameters).toBe("111/111");
+
+      await caller.close();
+    });
   });
 });


### PR DESCRIPTION
Fixes #620

The audio RED fmtp was derived as `payloadType + 1` inside the payload type assignment loop, which is only correct when RED is listed directly before the primary codec and payload types are auto-assigned. With `[opus, red]` order the fmtp referenced a payload type that does not exist on the m-line, and with explicit payload types RED got no fmtp at all because the assignment loop skips codecs that already have one.

The fmtp is now filled in after all payload types are assigned, referencing the first non-red, non-rtx audio codec. Explicitly configured `parameters` are left untouched. Behavior for the existing `[red, opus]` case is unchanged, covered by the existing negotiation tests; two new tests cover the `[opus, red]` order and explicit payload types (111/63 as negotiated by Chrome).

`npx vitest run ./tests` in packages/webrtc: 31 files, 185 passed, 3 skipped (pre-existing skips). The two new tests fail without the src change.
