### PR TITLE
Document the RED example and RTP processor utilities in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ requires at least Node.js 16
 https://github.com/shinyoshiaki/werift-webrtc/tree/master/examples
 
 - TURN/TLS HTTPS loopback sample: `examples/turn-loopback`
+- Audio RED (RFC 2198) send/recv sample: `examples/mediachannel/red`
+- RTP processing utilities (jitter buffer, RED encoder/decoder, DTX, NACK, lip sync): `packages/rtp/src/extra/processor`
 
 ### SFU
 


### PR DESCRIPTION
The processor utilities under `packages/rtp/src/extra/processor` (jitter buffer, RED encoder/decoder, DTX, NACK, lip sync) are easy to miss since neither the README nor the roadmap mention them; the roadmap section reads as if a jitter buffer does not exist yet. This adds two bullets to the examples section pointing at the RED sample and the processor directory.
